### PR TITLE
chore: rename CI job to build-test for SOC2 compliance

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

Rename the CI job in `.github/workflows/pr-check.yml` from `build` to `build-test` to support org-wide required status checks for SOC2 compliance (CC8.1).

## Why

We are standardizing all PR-triggered CI job names to `build-test` so we can add `required_status_checks` to the org-level "PR-Review" ruleset. This ensures all PRs have automated checks pass before merge, satisfying SOC2 CC8.1 requirements.

## What changed

- Renamed job key `build` → `build-test` in `.github/workflows/pr-check.yml`
- No changes to CI logic, steps, or behavior — only the job identifier changed

## Action needed

Please review and approve this PR. The CI will run identically — only the job name reported to GitHub changes.